### PR TITLE
[RIF counter] Remove RIF counter handler instead of removing the whole flex counter group

### DIFF
--- a/syncd/syncd_flex_counter.cpp
+++ b/syncd/syncd_flex_counter.cpp
@@ -853,7 +853,7 @@ void FlexCounter::removeRif(
         if (fc.isEmpty())
         {
             lkMgr.unlock();
-            removeInstance(instanceId);
+            fc.removeCollectCountersHandler(RIF_COUNTER_ID_LIST);
         }
         return;
     }
@@ -868,7 +868,7 @@ void FlexCounter::removeRif(
     if (fc.isEmpty())
     {
         lkMgr.unlock();
-        removeInstance(instanceId);
+        fc.removeCollectCountersHandler(RIF_COUNTER_ID_LIST);
     }
 }
 


### PR DESCRIPTION
Issue:
Issue Rif Counters can not work when removing one router interface #729

Issue scenario:
1- create some RIFs if no RIF exist
2- remove all RIFs
3- add new RIF
4- RIF counters are not working for new RIF

Root cause:
Occurred at step #2.
In function FlexCounter::removeRif in 201911 branch, removing the whole instance leads to RIF flex counter group to be removed.
After that when adding a new RIF, RIF flex counter group will be created again with zero poll interval
As a result zero poll interval RIF thread will not started and therefore the counters table will not filled up.
The symptom is N/A values in "show interfaces counters rif" command.

Fix:
Instead of removing the whole instance, will remove the counter from the m_collectCountersHandlers.


Signed-off-by: Basim Shalata <basims@nvidia.com>